### PR TITLE
feat: add repository file preview and download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
+        <!-- Markdown Rendering -->
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>0.64.8</version>
+        </dependency>
+
         <!-- JGit HTTP Support -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/src/main/resources/templates/admin/detail.html
+++ b/src/main/resources/templates/admin/detail.html
@@ -166,6 +166,13 @@
         .file-icon {
             font-size: 1.2rem;
         }
+        .file-link {
+            color: #3498db;
+            text-decoration: none;
+        }
+        .file-link:hover {
+            text-decoration: underline;
+        }
         .commit-list {
             max-height: 400px;
             overflow-y: auto;
@@ -436,7 +443,12 @@ git push -u origin main'">推送命令</pre>
                         <div class="file-name">
                             <span class="file-icon" th:text="${file.type == 'directory' ? '📁' : '📄'}">📄</span>
                             <a th:if="${file.type == 'directory'}" th:href="@{|/admin/repo/${repoName}?branch=${currentBranch}&path=${file.path}|}" th:text="${file.name}"></a>
-                            <span th:if="${file.type != 'directory'}" th:text="${file.name}"></span>
+                            <a th:if="${file.type != 'directory'}"
+                               th:href="@{|/admin/repo/${repoName}/file?branch=${currentBranch}&path=${file.path}|}"
+                               th:text="${file.name}"
+                               target="_blank"
+                               class="file-link"
+                               th:title="${'预览 ' + file.name}"></a>
                         </div>
                         <div th:text="${file.sizeFormatted}">1.2 KB</div>
                         <div th:text="${file.type == 'directory' ? '目录' : '文件'}">文件</div>

--- a/src/main/resources/templates/admin/file-viewer.html
+++ b/src/main/resources/templates/admin/file-viewer.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${fileName != null ? fileName : '文件预览'} + ' - ' + #{ui.repo.detail}">文件预览 - Mini Git Server</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f5f5f5;
+            color: #2c3e50;
+        }
+        .header {
+            background: #2c3e50;
+            color: #fff;
+            padding: 1rem 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .header a {
+            color: #fff;
+            text-decoration: none;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 2rem auto;
+            padding: 0 2rem 3rem;
+        }
+        .card {
+            background: #fff;
+            border-radius: 8px;
+            padding: 1.5rem 2rem;
+            margin-bottom: 1.5rem;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+        }
+        .file-info {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            margin-bottom: 1rem;
+        }
+        .info-item {
+            min-width: 200px;
+        }
+        .info-label {
+            font-size: 0.85rem;
+            color: #7f8c8d;
+        }
+        .info-value {
+            font-weight: 600;
+            margin-top: 0.25rem;
+            word-break: break-all;
+        }
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-top: 1rem;
+        }
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: #3498db;
+            color: #fff;
+            padding: 0.6rem 1.2rem;
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 0.95rem;
+        }
+        .btn.secondary {
+            background: #95a5a6;
+        }
+        .btn:hover {
+            background: #2980b9;
+        }
+        .btn.secondary:hover {
+            background: #7f8c8d;
+        }
+        .preview-panel {
+            background: #fff;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+            padding: 1.5rem 2rem;
+        }
+        pre {
+            background: #1e1e1e;
+            color: #f8f8f2;
+            padding: 1rem;
+            border-radius: 6px;
+            overflow-x: auto;
+            font-size: 0.9rem;
+            line-height: 1.5;
+        }
+        pre code {
+            font-family: "Fira Code", "Consolas", "Monaco", monospace;
+        }
+        .markdown-body {
+            font-size: 1rem;
+            line-height: 1.7;
+        }
+        .markdown-body h1,
+        .markdown-body h2,
+        .markdown-body h3 {
+            border-bottom: 1px solid #ecf0f1;
+            padding-bottom: 0.3rem;
+            margin-top: 1.5rem;
+        }
+        .markdown-body pre {
+            background: #2d2d2d;
+            color: #f8f8f2;
+        }
+        .markdown-body img {
+            max-width: 100%;
+        }
+        .image-preview {
+            max-width: 100%;
+            border-radius: 6px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+        }
+        .pdf-frame {
+            width: 100%;
+            height: 80vh;
+            border: none;
+            border-radius: 6px;
+            box-shadow: inset 0 0 0 1px #ecf0f1;
+        }
+        .alert {
+            background: #fdecea;
+            border: 1px solid #f5c2c7;
+            color: #b02a37;
+            padding: 1rem;
+            border-radius: 6px;
+            margin-bottom: 1rem;
+        }
+        @media (max-width: 768px) {
+            .container {
+                padding: 0 1rem 2rem;
+            }
+            .card, .preview-panel {
+                padding: 1rem;
+            }
+            .pdf-frame {
+                height: 60vh;
+            }
+        }
+    </style>
+</head>
+<body>
+<header class="header">
+    <div>
+        <a href="/admin">← 返回仓库列表</a>
+    </div>
+    <div>
+        <span th:text="${repoName}">repository.git</span>
+    </div>
+</header>
+
+<div class="container">
+    <div th:if="${error}" class="card">
+        <div class="alert" th:text="${error}">无法加载文件</div>
+        <div class="actions">
+            <a class="btn secondary" href="javascript:history.back()">返回上一页</a>
+        </div>
+    </div>
+
+    <div th:unless="${error}">
+        <div class="card">
+            <h2>📄 文件信息</h2>
+            <div class="file-info">
+                <div class="info-item">
+                    <div class="info-label">文件名</div>
+                    <div class="info-value" th:text="${fileName}">README.md</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">所在分支</div>
+                    <div class="info-value" th:text="${branch}">main</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">文件路径</div>
+                    <div class="info-value" th:text="${path}">docs/README.md</div>
+                </div>
+                <div class="info-item">
+                    <div class="info-label">文件大小</div>
+                    <div class="info-value" th:text="${fileSizeFormatted}">1.2 KB</div>
+                </div>
+            </div>
+            <div class="actions">
+                <a class="btn" th:href="@{|/admin/repo/${repoName}/file/raw?branch=${branch}&path=${path}|}" target="_blank">在线打开原文件</a>
+                <a class="btn" th:href="@{|/admin/repo/${repoName}/file/download?branch=${branch}&path=${path}|}">下载文件</a>
+                <a class="btn secondary" href="javascript:history.back()">返回</a>
+            </div>
+        </div>
+
+        <div class="preview-panel">
+            <h2>👀 文件预览</h2>
+
+            <div th:if="${!isPreviewSupported}" class="alert">
+                暂不支持此类型文件的在线预览，您可以使用上方按钮下载后查看。
+            </div>
+
+            <div th:if="${previewType == 'text'}">
+                <pre><code th:text="${textContent}"></code></pre>
+            </div>
+
+            <div th:if="${previewType == 'markdown'}" class="markdown-body" th:utext="${markdownHtml}">
+                Markdown 内容
+            </div>
+
+            <div th:if="${previewType == 'image'}">
+                <img class="image-preview" th:src="@{|/admin/repo/${repoName}/file/raw?branch=${branch}&path=${path}|}"
+                     th:alt="${fileName}" />
+            </div>
+
+            <div th:if="${previewType == 'pdf'}">
+                <iframe class="pdf-frame" th:src="@{|/admin/repo/${repoName}/file/raw?branch=${branch}&path=${path}|}"></iframe>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add git service helpers to obtain repository file metadata and raw bytes for previews
- extend the admin web controller with preview, raw, and download endpoints plus markdown rendering support
- deliver a dedicated file preview template, update the detail page links, and introduce flexmark for markdown parsing

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6cb8304c833384494312c3a5b6e1