### PR TITLE
fix: stabilize preview controller and repository helpers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,13 @@
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
 
+        <!-- Markdown rendering for preview pages -->
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-all</artifactId>
+            <version>0.64.8</version>
+        </dependency>
+
         <!-- JGit HTTP Support -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/src/main/java/com/minigit/controller/WebController.java
+++ b/src/main/java/com/minigit/controller/WebController.java
@@ -2,22 +2,37 @@ package com.minigit.controller;
 
 import com.minigit.service.GitRepositoryService;
 import com.minigit.service.RepositoryService;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.io.File;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Web管理界面控制器
@@ -27,6 +42,63 @@ import java.util.Map;
 public class WebController {
 
     private static final Logger logger = LoggerFactory.getLogger(WebController.class);
+
+    private static final Parser MARKDOWN_PARSER = Parser.builder().build();
+    private static final HtmlRenderer MARKDOWN_RENDERER = HtmlRenderer.builder().build();
+
+    private static final Set<String> MARKDOWN_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        "md", "markdown", "mdown", "mkd"
+    )));
+
+    private static final Set<String> TEXT_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        "txt", "log", "gitignore", "gitattributes", "java", "js", "ts", "css", "scss", "html", "xml",
+        "json", "yml", "yaml", "properties", "gradle", "py", "rb", "go", "rs", "sh", "bat", "sql",
+        "c", "h", "cpp", "hpp", "cs", "kt", "swift"
+    )));
+
+    private static final Set<String> IMAGE_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+        "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "avif"
+    )));
+
+    private static final Set<String> PDF_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Collections.singletonList("pdf")));
+
+    private static final Set<String> WORD_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("doc", "docx")));
+    private static final Set<String> EXCEL_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("xls", "xlsx", "csv")));
+    private static final Set<String> POWERPOINT_EXTENSIONS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("ppt", "pptx")));
+
+    private static final Map<String, String> HIGHLIGHT_LANGUAGE_MAP;
+
+    private static final int MAX_INLINE_PREVIEW_BYTES = 1_048_576; // 1 MB
+
+    static {
+        Map<String, String> languageMap = new HashMap<>();
+        languageMap.put("java", "java");
+        languageMap.put("js", "javascript");
+        languageMap.put("ts", "typescript");
+        languageMap.put("css", "css");
+        languageMap.put("scss", "scss");
+        languageMap.put("html", "html");
+        languageMap.put("xml", "xml");
+        languageMap.put("json", "json");
+        languageMap.put("yml", "yaml");
+        languageMap.put("yaml", "yaml");
+        languageMap.put("sh", "bash");
+        languageMap.put("bash", "bash");
+        languageMap.put("bat", "dos");
+        languageMap.put("py", "python");
+        languageMap.put("rb", "ruby");
+        languageMap.put("go", "go");
+        languageMap.put("rs", "rust");
+        languageMap.put("c", "c");
+        languageMap.put("h", "c");
+        languageMap.put("cpp", "cpp");
+        languageMap.put("hpp", "cpp");
+        languageMap.put("cs", "csharp");
+        languageMap.put("kt", "kotlin");
+        languageMap.put("swift", "swift");
+        languageMap.put("sql", "sql");
+        HIGHLIGHT_LANGUAGE_MAP = Collections.unmodifiableMap(languageMap);
+    }
 
     private final RepositoryService repositoryService;
     private final GitRepositoryService gitRepositoryService;
@@ -70,6 +142,324 @@ public class WebController {
             model.addAttribute("error", getMessage("internal.error"));
             return "error";
         }
+    }
+
+    @GetMapping("/admin/repo/{name}/file")
+    public String previewFile(@PathVariable String name,
+                              @RequestParam("path") String path,
+                              @RequestParam(value = "branch", required = false) String branch,
+                              Model model) {
+        String normalizedName;
+        File repoDir;
+
+        try {
+            normalizedName = repositoryService.normalizeRepositoryName(name);
+            if (!repositoryService.repositoryExists(normalizedName)) {
+                model.addAttribute("error", getMessage("repo.not.found", name));
+                return "error";
+            }
+
+            repoDir = repositoryService.getRepositoryPath(normalizedName);
+            GitRepositoryService.FileInfo fileInfo = gitRepositoryService.getFileInfo(repoDir, branch, path);
+            if (!"file".equals(fileInfo.getType())) {
+                model.addAttribute("error", "目录不支持在线预览");
+                return "error";
+            }
+
+            byte[] content = gitRepositoryService.getFileContent(repoDir, branch, path);
+            String detectedMime = detectMimeType(fileInfo.getName());
+            String previewType = determinePreviewType(fileInfo.getName(), detectedMime);
+            String mimeType = guessMimeType(fileInfo.getName(), previewType, detectedMime);
+
+            boolean tooLargeForInline = shouldRenderAsText(previewType) && content.length > MAX_INLINE_PREVIEW_BYTES;
+            boolean binaryDetected = shouldRenderAsText(previewType) && isLikelyBinary(content);
+            boolean inlinePreview = !tooLargeForInline && !binaryDetected && previewType != null && !"binary".equals(previewType);
+
+            model.addAttribute("repoName", normalizedName);
+            model.addAttribute("branch", branch);
+            model.addAttribute("fileName", fileInfo.getName());
+            model.addAttribute("filePath", fileInfo.getPath());
+            model.addAttribute("fileSize", fileInfo.getSize());
+            model.addAttribute("fileSizeFormatted", fileInfo.getSizeFormatted());
+            model.addAttribute("previewType", previewType);
+            model.addAttribute("inlinePreview", inlinePreview);
+            model.addAttribute("mimeType", mimeType);
+            model.addAttribute("highlightLanguage", detectHighlightLanguage(fileInfo.getName()));
+            model.addAttribute("tooLargeForInline", tooLargeForInline);
+            model.addAttribute("binaryDetected", binaryDetected);
+
+            String encodedPath = encodeUrlParam(path);
+            String query = "path=" + encodedPath;
+            if (branch != null && !branch.isEmpty()) {
+                query += "&branch=" + encodeUrlParam(branch);
+            }
+            model.addAttribute("downloadUrl", "/admin/repo/" + normalizedName + "/file/download?" + query);
+            model.addAttribute("rawUrl", "/admin/repo/" + normalizedName + "/file/raw?" + query);
+
+            StringBuilder backUrl = new StringBuilder("/admin/repo/").append(normalizedName);
+            String parent = getParentPath(path);
+            if (branch != null && !branch.isEmpty()) {
+                backUrl.append("?branch=").append(encodeUrlParam(branch));
+                if (!parent.isEmpty()) {
+                    backUrl.append("&path=").append(encodeUrlParam(parent));
+                }
+            } else if (!parent.isEmpty()) {
+                backUrl.append("?path=").append(encodeUrlParam(parent));
+            }
+            model.addAttribute("backUrl", backUrl.toString());
+
+            if (inlinePreview) {
+                if ("markdown".equals(previewType)) {
+                    String markdown = new String(content, StandardCharsets.UTF_8);
+                    Node document = MARKDOWN_PARSER.parse(markdown);
+                    String html = MARKDOWN_RENDERER.render(document);
+                    model.addAttribute("markdownHtml", html);
+                } else if ("text".equals(previewType)) {
+                    model.addAttribute("textContent", new String(content, StandardCharsets.UTF_8));
+                } else if ("image".equals(previewType)) {
+                    model.addAttribute("imageData", "data:" + (mimeType != null ? mimeType : "image/*") + ";base64," + Base64.getEncoder().encodeToString(content));
+                } else if ("pdf".equals(previewType)) {
+                    model.addAttribute("pdfData", "data:" + (mimeType != null ? mimeType : "application/pdf") + ";base64," + Base64.getEncoder().encodeToString(content));
+                }
+            }
+
+            boolean requiresClientRender = Arrays.asList("word", "excel", "powerpoint").contains(previewType);
+            model.addAttribute("clientRenderOffice", requiresClientRender);
+            model.addAttribute("previewAvailable", inlinePreview || requiresClientRender);
+
+            return "admin/file-viewer";
+        } catch (IllegalArgumentException e) {
+            logger.warn("File preview failed for repo {} path {}: {}", name, path, e.getMessage());
+            model.addAttribute("error", e.getMessage());
+            return "error";
+        } catch (Exception e) {
+            logger.error("Unexpected error preparing file preview for repo {} path {}", name, path, e);
+            model.addAttribute("error", "加载文件预览时发生错误: " + e.getMessage());
+            return "error";
+        }
+    }
+
+    @GetMapping("/admin/repo/{name}/file/raw")
+    public ResponseEntity<byte[]> rawFile(@PathVariable String name,
+                                          @RequestParam("path") String path,
+                                          @RequestParam(value = "branch", required = false) String branch) {
+        return serveFileContent(name, path, branch, false);
+    }
+
+    @GetMapping("/admin/repo/{name}/file/download")
+    public ResponseEntity<byte[]> downloadFile(@PathVariable String name,
+                                               @RequestParam("path") String path,
+                                               @RequestParam(value = "branch", required = false) String branch) {
+        return serveFileContent(name, path, branch, true);
+    }
+
+    private ResponseEntity<byte[]> serveFileContent(String repoName, String path, String branch, boolean attachment) {
+        try {
+            String normalizedName = repositoryService.normalizeRepositoryName(repoName);
+            if (!repositoryService.repositoryExists(normalizedName)) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            }
+
+            File repoDir = repositoryService.getRepositoryPath(normalizedName);
+            GitRepositoryService.FileInfo fileInfo = gitRepositoryService.getFileInfo(repoDir, branch, path);
+            if (!"file".equals(fileInfo.getType())) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+            }
+
+            byte[] content = gitRepositoryService.getFileContent(repoDir, branch, path);
+            String detectedMime = detectMimeType(fileInfo.getName());
+            String previewType = determinePreviewType(fileInfo.getName(), detectedMime);
+            String mimeType = guessMimeType(fileInfo.getName(), previewType, detectedMime);
+
+            HttpHeaders headers = new HttpHeaders();
+            if (mimeType != null) {
+                headers.setContentType(MediaType.parseMediaType(mimeType));
+            } else {
+                headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+            }
+            headers.set(HttpHeaders.CONTENT_DISPOSITION, buildContentDisposition(attachment, fileInfo.getName()));
+            headers.setContentLength(content.length);
+
+            return new ResponseEntity<>(content, headers, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            logger.warn("Serve file failed for repo {} path {}: {}", repoName, path, e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (Exception e) {
+            logger.error("Error serving file {} from repo {}", path, repoName, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    private String determinePreviewType(String fileName, String mimeType) {
+        String extension = extractExtension(fileName);
+
+        if (extension != null) {
+            if (MARKDOWN_EXTENSIONS.contains(extension)) {
+                return "markdown";
+            }
+            if (TEXT_EXTENSIONS.contains(extension)) {
+                return "text";
+            }
+            if (IMAGE_EXTENSIONS.contains(extension)) {
+                return "image";
+            }
+            if (PDF_EXTENSIONS.contains(extension)) {
+                return "pdf";
+            }
+            if (WORD_EXTENSIONS.contains(extension)) {
+                return "word";
+            }
+            if (EXCEL_EXTENSIONS.contains(extension)) {
+                return "excel";
+            }
+            if (POWERPOINT_EXTENSIONS.contains(extension)) {
+                return "powerpoint";
+            }
+        }
+
+        if (mimeType != null) {
+            if (mimeType.startsWith("text/")) {
+                return "text";
+            }
+            if (mimeType.startsWith("image/")) {
+                return "image";
+            }
+            if (mimeType.equals("application/pdf")) {
+                return "pdf";
+            }
+        }
+
+        return "binary";
+    }
+
+    private String detectHighlightLanguage(String fileName) {
+        String extension = extractExtension(fileName);
+        if (extension == null) {
+            return null;
+        }
+        return HIGHLIGHT_LANGUAGE_MAP.get(extension);
+    }
+
+    private boolean shouldRenderAsText(String previewType) {
+        return "text".equals(previewType) || "markdown".equals(previewType);
+    }
+
+    private boolean isLikelyBinary(byte[] content) {
+        int controlChars = 0;
+        int length = Math.min(content.length, 4096);
+        for (int i = 0; i < length; i++) {
+            int b = content[i] & 0xFF;
+            if (b == 0) {
+                return true;
+            }
+            if (b < 0x09 || (b > 0x0D && b < 0x20)) {
+                controlChars++;
+            }
+        }
+        return controlChars > length / 8;
+    }
+
+    private String detectMimeType(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        try {
+            return URLConnection.getFileNameMap().getContentTypeFor(fileName);
+        } catch (Exception e) {
+            logger.debug("Failed to detect mime type for {} via URLConnection: {}", fileName, e.getMessage());
+            return null;
+        }
+    }
+
+    private String guessMimeType(String fileName, String previewType, String detectedMime) {
+        String extension = extractExtension(fileName);
+        if ("markdown".equals(previewType)) {
+            return "text/markdown;charset=UTF-8";
+        }
+        if ("text".equals(previewType)) {
+            return "text/plain;charset=UTF-8";
+        }
+        if ("image".equals(previewType)) {
+            if ("svg".equals(extension)) {
+                return "image/svg+xml";
+            }
+            if (extension != null) {
+                return "image/" + extension.replace("jpg", "jpeg");
+            }
+        }
+        if ("pdf".equals(previewType)) {
+            return "application/pdf";
+        }
+        if ("word".equals(previewType)) {
+            if ("docx".equals(extension)) {
+                return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+            }
+            return "application/msword";
+        }
+        if ("excel".equals(previewType)) {
+            if ("xlsx".equals(extension)) {
+                return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+            }
+            if ("csv".equals(extension)) {
+                return "text/csv;charset=UTF-8";
+            }
+            return "application/vnd.ms-excel";
+        }
+        if ("powerpoint".equals(previewType)) {
+            if ("pptx".equals(extension)) {
+                return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+            }
+            return "application/vnd.ms-powerpoint";
+        }
+
+        if (detectedMime != null && !detectedMime.isEmpty()) {
+            return detectedMime;
+        }
+        return detectMimeType(fileName);
+    }
+
+    private String buildContentDisposition(boolean attachment, String fileName) {
+        String type = attachment ? "attachment" : "inline";
+        String escaped = fileName.replace("\"", "\\\"");
+        return type + "; filename=\"" + escaped + "\"; filename*=UTF-8''" + encodeFileName(fileName);
+    }
+
+    private String encodeFileName(String fileName) {
+        try {
+            return URLEncoder.encode(fileName, StandardCharsets.UTF_8.name()).replaceAll("\\+", "%20");
+        } catch (Exception e) {
+            return fileName;
+        }
+    }
+
+    private String encodeUrlParam(String value) {
+        if (value == null) {
+            return "";
+        }
+        return encodeFileName(value);
+    }
+
+    private String extractExtension(String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        int dot = fileName.lastIndexOf('.');
+        if (dot < 0 || dot == fileName.length() - 1) {
+            return null;
+        }
+        return fileName.substring(dot + 1).toLowerCase(Locale.ROOT);
+    }
+
+    private String getParentPath(String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return "";
+        }
+        String trimmed = path.trim();
+        int idx = trimmed.lastIndexOf('/');
+        if (idx <= 0) {
+            return "";
+        }
+        return trimmed.substring(0, idx);
     }
 
     /**

--- a/src/main/java/com/minigit/service/GitRepositoryService.java
+++ b/src/main/java/com/minigit/service/GitRepositoryService.java
@@ -3,10 +3,12 @@ package com.minigit.service;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.LogCommand;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.slf4j.Logger;
@@ -109,14 +111,14 @@ public class GitRepositoryService {
      */
     public List<CommitInfo> getCommitLog(File repoDir, int maxCount) throws Exception {
         List<CommitInfo> commits = new ArrayList<>();
-        
+
         logger.debug("Getting commit log for repository: {}", repoDir.getAbsolutePath());
-        
+
         try (Repository repository = new FileRepositoryBuilder()
                 .setGitDir(repoDir)
                 .setMustExist(true)
                 .build()) {
-            
+
             try (Git git = new Git(repository)) {
                 // 首先尝试获取HEAD引用
                 Ref head = repository.exactRef("HEAD");
@@ -124,11 +126,11 @@ public class GitRepositoryService {
                     logger.warn("No HEAD reference found in repository: {}", repoDir.getAbsolutePath());
                     return commits;
                 }
-                
+
                 LogCommand logCommand = git.log()
                     .add(head.getObjectId())
                     .setMaxCount(maxCount);
-                
+
                 for (RevCommit commit : logCommand.call()) {
                     CommitInfo info = new CommitInfo();
                     info.setId(commit.getId().getName());
@@ -138,17 +140,17 @@ public class GitRepositoryService {
                     info.setEmail(commit.getAuthorIdent().getEmailAddress());
                     info.setDate(commit.getAuthorIdent().getWhen());
                     info.setDateFormatted(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(info.getDate()));
-                    
+
                     commits.add(info);
                 }
-                
+
                 logger.debug("Found {} commits in repository", commits.size());
             }
         }
-        
+
         return commits;
     }
-    
+
     /**
      * 获取指定分支的提交日志（branchName 可以是短名 "master" 或完整 refs/heads/...）
      */
@@ -163,37 +165,7 @@ public class GitRepositoryService {
                 .build()) {
 
             try (Git git = new Git(repository)) {
-                ObjectId startId = null;
-
-                // 如果没有指定分支，则使用 HEAD
-                if (branchName == null || branchName.isEmpty()) {
-                    Ref head = repository.exactRef("HEAD");
-                    if (head == null) {
-                        logger.warn("No HEAD found for repository {}", repoDir.getAbsolutePath());
-                        return commits;
-                    }
-                    startId = head.getObjectId();
-                } else {
-                    // 规范化分支名
-                    String resolvedBranch = branchName;
-                    if (!resolvedBranch.startsWith("refs/")) {
-                        // 假定为本地分支短名
-                        resolvedBranch = "refs/heads/" + resolvedBranch;
-                    }
-
-                    // 尝试解析引用到对象ID
-                    startId = repository.resolve(resolvedBranch);
-                    if (startId == null) {
-                        logger.warn("Branch {} could not be resolved in repository {}", resolvedBranch, repoDir.getAbsolutePath());
-                        // 作为退路尝试 HEAD
-                        Ref head = repository.exactRef("HEAD");
-                        if (head != null) {
-                            startId = head.getObjectId();
-                        } else {
-                            return commits;
-                        }
-                    }
-                }
+                ObjectId startId = resolveBranchObjectId(repository, branchName);
 
                 if (startId == null) {
                     logger.warn("No start commit found for repository {}", repoDir.getAbsolutePath());
@@ -229,45 +201,45 @@ public class GitRepositoryService {
      */
     public List<BranchInfo> getBranches(File repoDir) throws Exception {
         List<BranchInfo> branches = new ArrayList<>();
-        
+
         logger.debug("Getting branches for repository: {}", repoDir.getAbsolutePath());
-        
+
         try (Repository repository = new FileRepositoryBuilder()
                 .setGitDir(repoDir)
                 .setMustExist(true)
                 .build()) {
-            
+
             try (Git git = new Git(repository)) {
                 // 获取所有本地分支
                 List<Ref> localRefs = git.branchList().call();
                 logger.debug("Found {} local branch references", localRefs.size());
-                
+
                 // 获取所有远程分支
                 List<Ref> remoteRefs = git.branchList().setListMode(org.eclipse.jgit.api.ListBranchCommand.ListMode.REMOTE).call();
                 logger.debug("Found {} remote branch references", remoteRefs.size());
-                
+
                 // 合并所有分支引用
                 List<Ref> allRefs = new ArrayList<>();
                 allRefs.addAll(localRefs);
                 allRefs.addAll(remoteRefs);
-                
+
                 String defaultBranch = getDefaultBranch(repository);
                 logger.debug("Default branch: {}", defaultBranch);
-                
+
                 for (Ref ref : allRefs) {
-                    logger.debug("Processing ref: {} -> {}", ref.getName(), 
+                    logger.debug("Processing ref: {} -> {}", ref.getName(),
                         ref.getObjectId() != null ? ref.getObjectId().getName() : "null");
-                    
+
                     // 只处理本地分支 (refs/heads/*)
                     if (!ref.getName().startsWith("refs/heads/")) {
                         continue;
                     }
-                    
+
                     BranchInfo info = new BranchInfo();
                     info.setName(ref.getName());
                     info.setShortName(Repository.shortenRefName(ref.getName()));
                     info.setDefault(ref.getName().equals(defaultBranch));
-                    
+
                     // 获取最后一次提交信息
                     ObjectId objectId = ref.getObjectId();
                     if (objectId != null) {
@@ -277,7 +249,7 @@ public class GitRepositoryService {
                                 info.setLastCommitId(commit.getId().abbreviate(8).name());
                                 info.setLastCommitMessage(commit.getShortMessage());
                                 info.setLastCommitDate(commit.getAuthorIdent().getWhen());
-                                logger.debug("Branch {} last commit: {} - {}", 
+                                logger.debug("Branch {} last commit: {} - {}",
                                     info.getShortName(), info.getLastCommitId(), info.getLastCommitMessage());
                                 break;
                             }
@@ -285,14 +257,14 @@ public class GitRepositoryService {
                             logger.warn("Failed to get last commit for branch {}: {}", ref.getName(), e.getMessage());
                         }
                     }
-                    
+
                     branches.add(info);
                 }
-                
+
                 logger.debug("Returning {} branches", branches.size());
             }
         }
-        
+
         return branches;
     }
 
@@ -301,46 +273,36 @@ public class GitRepositoryService {
      */
     public List<FileInfo> getFileList(File repoDir, String branchName, String path) throws Exception {
         List<FileInfo> files = new ArrayList<>();
-        
-        logger.debug("Getting file list for repository: {}, branch: {}, path: {}", 
+
+        logger.debug("Getting file list for repository: {}, branch: {}, path: {}",
             repoDir.getAbsolutePath(), branchName, path);
-        
+
         try (Repository repository = new FileRepositoryBuilder()
                 .setGitDir(repoDir)
                 .setMustExist(true)
                 .build()) {
-            
-            try (Git git = new Git(repository)) {
-                // 如果没有指定分支，使用默认分支
-                if (branchName == null || branchName.isEmpty()) {
-                    branchName = getDefaultBranch(repository);
-                    if (branchName == null) {
-                        logger.warn("No default branch found for repository: {}", repoDir.getAbsolutePath());
-                        return files;
-                    }
-                }
-                
-                // 确保分支名称格式正确
-                if (!branchName.startsWith("refs/heads/")) {
-                    branchName = "refs/heads/" + branchName;
-                }
-                
-                ObjectId branchId = repository.resolve(branchName);
-                if (branchId == null) {
-                    logger.warn("Branch {} not found in repository: {}", branchName, repoDir.getAbsolutePath());
-                    return files;
-                }
-                
-                RevTree tree = repository.parseCommit(branchId).getTree();
+
+            ObjectId branchId = resolveBranchObjectId(repository, branchName);
+            if (branchId == null) {
+                logger.warn("Branch {} not found in repository: {}", branchName, repoDir.getAbsolutePath());
+                return files;
+            }
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(branchId);
+                RevTree tree = commit.getTree();
+
+                String normalizedPath = normalizePath(path);
 
                 try (TreeWalk treeWalk = new TreeWalk(repository)) {
-                    if (path != null && !path.isEmpty() && !"/".equals(path)) {
-                        TreeWalk pathWalk = TreeWalk.forPath(repository, path, tree);
-                        if (pathWalk == null || !pathWalk.isSubtree()) {
-                            logger.debug("Path {} not found in repository", path);
-                            return files;
+                    if (!normalizedPath.isEmpty()) {
+                        try (TreeWalk dirWalk = TreeWalk.forPath(repository, normalizedPath, tree)) {
+                            if (dirWalk == null || !dirWalk.isSubtree()) {
+                                logger.debug("Path {} not found in repository", normalizedPath);
+                                return files;
+                            }
+                            treeWalk.addTree(dirWalk.getObjectId(0));
                         }
-                        treeWalk.addTree(pathWalk.getObjectId(0));
                     } else {
                         treeWalk.addTree(tree);
                     }
@@ -351,16 +313,21 @@ public class GitRepositoryService {
                         FileInfo info = new FileInfo();
                         info.setName(treeWalk.getNameString());
                         String filePath = treeWalk.getPathString();
-                        if (path != null && !path.isEmpty()) {
-                            filePath = path + "/" + filePath;
+                        if (!normalizedPath.isEmpty()) {
+                            filePath = normalizedPath + "/" + treeWalk.getNameString();
                         }
                         info.setPath(filePath);
-                        info.setType(treeWalk.isSubtree() ? "directory" : "file");
-                        
-                        if (!treeWalk.isSubtree()) {
-                            // 获取文件大小
+
+                        boolean isDirectory = treeWalk.isSubtree();
+                        info.setType(isDirectory ? "directory" : "file");
+
+                        if (isDirectory) {
+                            info.setSize(0);
+                            info.setSizeFormatted("-");
+                        } else {
                             try {
-                                long size = repository.open(treeWalk.getObjectId(0)).getSize();
+                                ObjectLoader loader = repository.open(treeWalk.getObjectId(0));
+                                long size = loader.getSize();
                                 info.setSize(size);
                                 info.setSizeFormatted(formatBytes(size));
                             } catch (Exception e) {
@@ -368,19 +335,14 @@ public class GitRepositoryService {
                                 info.setSizeFormatted("0 B");
                                 logger.debug("Failed to get size for file {}: {}", info.getName(), e.getMessage());
                             }
-                        } else {
-                            info.setSize(0);
-                            info.setSizeFormatted("-");
                         }
-                        
+
                         files.add(info);
                     }
                 }
-                
-                logger.debug("Found {} files in repository", files.size());
             }
         }
-        
+
         // 排序：目录在前，然后按名称排序
         files.sort((a, b) -> {
             if (a.getType().equals(b.getType())) {
@@ -388,75 +350,100 @@ public class GitRepositoryService {
             }
             return "directory".equals(a.getType()) ? -1 : 1;
         });
-        
+
         return files;
     }
 
     /**
-     * 获取默认分支
+     * 获取文件详细信息
      */
-    private String getDefaultBranch(Repository repository) throws IOException {
-        // 首先检查HEAD的符号引用
-        Ref head = repository.exactRef("HEAD");
-        if (head != null && head.isSymbolic() && head.getTarget() != null) {
-            String targetName = head.getTarget().getName();
-            logger.debug("HEAD points to symbolic ref: {}", targetName);
-            return targetName;
+    public FileInfo getFileInfo(File repoDir, String branchName, String path) throws Exception {
+        if (path == null || path.trim().isEmpty()) {
+            throw new IllegalArgumentException("File path must not be empty");
         }
-        
-        // 如果HEAD直接指向提交对象，尝试找到指向同一提交的分支
-        if (head != null && head.getObjectId() != null) {
-            ObjectId headObjectId = head.getObjectId();
-            logger.debug("HEAD points to commit: {}", headObjectId.getName());
-            
-            // 尝试常见的默认分支名
-            for (String branch : Arrays.asList("refs/heads/master", "refs/heads/main")) {
-                Ref branchRef = repository.exactRef(branch);
-                if (branchRef != null && headObjectId.equals(branchRef.getObjectId())) {
-                    logger.debug("Found matching branch: {}", branch);
-                    return branch;
-                }
+
+        String normalizedPath = normalizePath(path);
+        if (normalizedPath.isEmpty()) {
+            throw new IllegalArgumentException("File path must not point to repository root");
+        }
+
+        try (Repository repository = new FileRepositoryBuilder()
+                .setGitDir(repoDir)
+                .setMustExist(true)
+                .build()) {
+
+            ObjectId branchId = resolveBranchObjectId(repository, branchName);
+            if (branchId == null) {
+                throw new IllegalArgumentException("Branch not found: " + (branchName == null ? "(default)" : branchName));
             }
-            
-            // 如果没有找到匹配的，返回第一个分支
-            try {
-                Map<String, Ref> refs = repository.getAllRefs();
-                for (Map.Entry<String, Ref> entry : refs.entrySet()) {
-                    if (entry.getKey().startsWith("refs/heads/") && 
-                        headObjectId.equals(entry.getValue().getObjectId())) {
-                        logger.debug("Found first matching branch: {}", entry.getKey());
-                        return entry.getKey();
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(branchId);
+                RevTree tree = commit.getTree();
+
+                try (TreeWalk treeWalk = TreeWalk.forPath(repository, normalizedPath, tree)) {
+                    if (treeWalk == null) {
+                        throw new IllegalArgumentException("File not found: " + path);
                     }
+
+                    FileInfo info = new FileInfo();
+                    info.setName(treeWalk.getNameString());
+                    info.setPath(normalizedPath);
+
+                    if (treeWalk.isSubtree()) {
+                        info.setType("directory");
+                        info.setSize(0);
+                        info.setSizeFormatted("-");
+                    } else {
+                        info.setType("file");
+                        ObjectLoader loader = repository.open(treeWalk.getObjectId(0));
+                        long size = loader.getSize();
+                        info.setSize(size);
+                        info.setSizeFormatted(formatBytes(size));
+                    }
+
+                    return info;
                 }
-            } catch (Exception e) {
-                logger.warn("Failed to get all refs: {}", e.getMessage());
             }
         }
-        
-        // 最后尝试：返回第一个存在的分支
-        for (String branch : Arrays.asList("refs/heads/master", "refs/heads/main")) {
-            if (repository.exactRef(branch) != null) {
-                logger.debug("Using fallback branch: {}", branch);
-                return branch;
-            }
-        }
-        
-        logger.warn("No default branch found for repository: {}", repository.getDirectory());
-        return null;
     }
 
     /**
-     * 格式化字节大小
+     * 获取文件内容
      */
-    private String formatBytes(long bytes) {
-        if (bytes < 1024) {
-            return bytes + " B";
-        } else if (bytes < 1024 * 1024) {
-            return String.format("%.1f KB", bytes / 1024.0);
-        } else if (bytes < 1024 * 1024 * 1024) {
-            return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
-        } else {
-            return String.format("%.1f GB", bytes / (1024.0 * 1024.0 * 1024.0));
+    public byte[] getFileContent(File repoDir, String branchName, String path) throws Exception {
+        if (path == null || path.trim().isEmpty()) {
+            throw new IllegalArgumentException("File path must not be empty");
+        }
+
+        String normalizedPath = normalizePath(path);
+        if (normalizedPath.isEmpty()) {
+            throw new IllegalArgumentException("File path must not point to repository root");
+        }
+
+        try (Repository repository = new FileRepositoryBuilder()
+                .setGitDir(repoDir)
+                .setMustExist(true)
+                .build()) {
+
+            ObjectId branchId = resolveBranchObjectId(repository, branchName);
+            if (branchId == null) {
+                throw new IllegalArgumentException("Branch not found: " + (branchName == null ? "(default)" : branchName));
+            }
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(branchId);
+                RevTree tree = commit.getTree();
+
+                try (TreeWalk treeWalk = TreeWalk.forPath(repository, normalizedPath, tree)) {
+                    if (treeWalk == null || treeWalk.isSubtree()) {
+                        throw new IllegalArgumentException("File not found or is a directory: " + path);
+                    }
+
+                    ObjectLoader loader = repository.open(treeWalk.getObjectId(0));
+                    return loader.getBytes();
+                }
+            }
         }
     }
 
@@ -469,7 +456,7 @@ public class GitRepositoryService {
                     .setGitDir(repoDir)
                     .setMustExist(true)
                     .build()) {
-                
+
                 Ref head = repository.exactRef("HEAD");
                 boolean isEmpty = (head == null || head.getObjectId() == null);
                 logger.debug("Repository {} is empty: {}", repoDir.getAbsolutePath(), isEmpty);
@@ -510,6 +497,120 @@ public class GitRepositoryService {
                 .setName(newBranch)
                 .setStartPoint(sourceBranch)
                 .call();
+        }
+    }
+
+    private String normalizePath(String path) {
+        if (path == null) {
+            return "";
+        }
+        String trimmed = path.trim();
+        if (trimmed.isEmpty() || "/".equals(trimmed)) {
+            return "";
+        }
+        if (trimmed.startsWith("/")) {
+            trimmed = trimmed.substring(1);
+        }
+        if (trimmed.endsWith("/") && trimmed.length() > 1) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    private ObjectId resolveBranchObjectId(Repository repository, String branchName) throws IOException {
+        if (branchName != null && !branchName.trim().isEmpty()) {
+            ObjectId direct = repository.resolve(branchName);
+            if (direct != null) {
+                return direct;
+            }
+        }
+
+        String resolved = branchName;
+        if (resolved == null || resolved.trim().isEmpty()) {
+            resolved = getDefaultBranch(repository);
+        }
+
+        if (resolved == null || resolved.trim().isEmpty()) {
+            return null;
+        }
+
+        if (!resolved.startsWith("refs/")) {
+            resolved = "refs/heads/" + resolved;
+        }
+
+        ObjectId branchId = repository.resolve(resolved);
+        if (branchId == null && branchName != null && branchName.startsWith("refs/")) {
+            branchId = repository.resolve(branchName);
+        }
+
+        return branchId;
+    }
+
+    /**
+     * 获取默认分支
+     */
+    private String getDefaultBranch(Repository repository) throws IOException {
+        // 首先检查HEAD的符号引用
+        Ref head = repository.exactRef("HEAD");
+        if (head != null && head.isSymbolic() && head.getTarget() != null) {
+            String targetName = head.getTarget().getName();
+            logger.debug("HEAD points to symbolic ref: {}", targetName);
+            return targetName;
+        }
+
+        // 如果HEAD直接指向提交对象，尝试找到指向同一提交的分支
+        if (head != null && head.getObjectId() != null) {
+            ObjectId headObjectId = head.getObjectId();
+            logger.debug("HEAD points to commit: {}", headObjectId.getName());
+
+            // 尝试常见的默认分支名
+            for (String branch : Arrays.asList("refs/heads/master", "refs/heads/main")) {
+                Ref branchRef = repository.exactRef(branch);
+                if (branchRef != null && headObjectId.equals(branchRef.getObjectId())) {
+                    logger.debug("Found matching branch: {}", branch);
+                    return branch;
+                }
+            }
+
+            // 如果没有找到匹配的，返回第一个分支
+            try {
+                Map<String, Ref> refs = repository.getAllRefs();
+                for (Map.Entry<String, Ref> entry : refs.entrySet()) {
+                    if (entry.getKey().startsWith("refs/heads/") &&
+                        headObjectId.equals(entry.getValue().getObjectId())) {
+                        logger.debug("Found first matching branch: {}", entry.getKey());
+                        return entry.getKey();
+                    }
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to get all refs: {}", e.getMessage());
+            }
+        }
+
+        // 最后尝试：返回第一个存在的分支
+        for (String branch : Arrays.asList("refs/heads/master", "refs/heads/main")) {
+            if (repository.exactRef(branch) != null) {
+                logger.debug("Using fallback branch: {}", branch);
+                return branch;
+            }
+        }
+
+        logger.warn("No default branch found for repository: {}", repository.getDirectory());
+        return null;
+    }
+
+    /**
+     * 格式化字节大小
+     */
+    private String formatBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        } else if (bytes < 1024 * 1024) {
+            return String.format("%.1f KB", bytes / 1024.0);
+        } else if (bytes < 1024 * 1024 * 1024) {
+            return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
+        } else {
+            return String.format("%.1f GB", bytes / (1024.0 * 1024.0 * 1024.0));
         }
     }
 }

--- a/src/main/resources/templates/admin/detail.html
+++ b/src/main/resources/templates/admin/detail.html
@@ -166,6 +166,13 @@
         .file-icon {
             font-size: 1.2rem;
         }
+        .file-link {
+            color: #3498db;
+            text-decoration: none;
+        }
+        .file-link:hover {
+            text-decoration: underline;
+        }
         .commit-list {
             max-height: 400px;
             overflow-y: auto;
@@ -436,7 +443,13 @@ git push -u origin main'">推送命令</pre>
                         <div class="file-name">
                             <span class="file-icon" th:text="${file.type == 'directory' ? '📁' : '📄'}">📄</span>
                             <a th:if="${file.type == 'directory'}" th:href="@{|/admin/repo/${repoName}?branch=${currentBranch}&path=${file.path}|}" th:text="${file.name}"></a>
-                            <span th:if="${file.type != 'directory'}" th:text="${file.name}"></span>
+                            <a th:if="${file.type != 'directory'}"
+                               th:href="@{|/admin/repo/${repoName}/file?path=${file.path}${currentBranch != null ? '&branch=' + currentBranch : ''}|}"
+                               target="_blank"
+                               rel="noopener"
+                               class="file-link"
+                               th:title="${'预览 ' + file.name}"
+                               th:text="${file.name}"></a>
                         </div>
                         <div th:text="${file.sizeFormatted}">1.2 KB</div>
                         <div th:text="${file.type == 'directory' ? '目录' : '文件'}">文件</div>

--- a/src/main/resources/templates/admin/file-viewer.html
+++ b/src/main/resources/templates/admin/file-viewer.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:lang="${#locale.language}">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${fileName != null ? fileName : '文件预览'} + ' - Mini Git Server'">文件预览 - Mini Git Server</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docx-preview@0.3.1/dist/docx-preview.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pptxjs@2.12.0/dist/pptxjs.min.css">
+    <style>
+        body {
+            margin: 0;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: #f5f5f5;
+            color: #2c3e50;
+        }
+        .header {
+            background: #2c3e50;
+            color: #fff;
+            padding: 1rem 2rem;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+        .header a {
+            color: #fff;
+            text-decoration: none;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 2rem auto;
+            padding: 0 1.5rem 3rem;
+        }
+        .card {
+            background: #fff;
+            border-radius: 8px;
+            padding: 1.75rem 2rem;
+            margin-bottom: 1.5rem;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+        }
+        .card h2 {
+            margin-top: 0;
+            margin-bottom: 1.25rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .info-grid {
+            display: grid;
+            grid-template-columns: 150px 1fr;
+            gap: 0.5rem 1rem;
+        }
+        .info-label {
+            font-size: 0.85rem;
+            color: #7f8c8d;
+        }
+        .info-value {
+            font-weight: 600;
+            word-break: break-all;
+        }
+        .actions {
+            margin-top: 1.5rem;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+        }
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            background: #3498db;
+            color: #fff;
+            padding: 0.6rem 1.3rem;
+            border-radius: 5px;
+            text-decoration: none;
+            font-size: 0.95rem;
+        }
+        .btn.secondary {
+            background: #95a5a6;
+        }
+        .btn:hover {
+            background: #2980b9;
+        }
+        .btn.secondary:hover {
+            background: #7f8c8d;
+        }
+        .preview-card {
+            min-height: 360px;
+        }
+        pre {
+            background: #1e1e1e;
+            color: #f8f8f2;
+            padding: 1rem;
+            border-radius: 6px;
+            overflow-x: auto;
+            font-size: 0.95rem;
+            line-height: 1.55;
+        }
+        .code-block {
+            font-family: "Fira Code", "Consolas", "Monaco", monospace;
+        }
+        .markdown-body {
+            font-size: 1rem;
+            line-height: 1.7;
+        }
+        .markdown-body h1,
+        .markdown-body h2,
+        .markdown-body h3 {
+            border-bottom: 1px solid #ecf0f1;
+            padding-bottom: 0.35rem;
+        }
+        .markdown-body pre {
+            background: #2d2d2d;
+            color: #f8f8f2;
+            padding: 1rem;
+            border-radius: 6px;
+            overflow-x: auto;
+        }
+        .preview-placeholder {
+            text-align: center;
+            color: #7f8c8d;
+            padding: 2rem 1rem;
+        }
+        .image-preview {
+            max-width: 100%;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+        }
+        .pdf-frame {
+            width: 100%;
+            height: 80vh;
+            border: none;
+            border-radius: 6px;
+            box-shadow: inset 0 0 0 1px #ecf0f1;
+        }
+        .docx-wrapper {
+            background: #ffffff;
+            padding: 1rem;
+            border-radius: 6px;
+            box-shadow: inset 0 0 0 1px #e0e6ed;
+        }
+        .excel-container {
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+        .excel-container table {
+            border-collapse: collapse;
+            width: 100%;
+        }
+        .excel-container th,
+        .excel-container td {
+            border: 1px solid #d0d7de;
+            padding: 0.45rem 0.6rem;
+            font-size: 0.9rem;
+        }
+        .excel-container th {
+            background: #f4f6f8;
+        }
+        .alert {
+            margin-top: 1rem;
+            background: #fff6d5;
+            color: #856404;
+            padding: 0.85rem 1rem;
+            border-radius: 6px;
+            border: 1px solid #ffe9a8;
+        }
+        .preview-meta {
+            margin-top: 0.75rem;
+            font-size: 0.9rem;
+            color: #7f8c8d;
+        }
+        .office-progress {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 260px;
+            color: #7f8c8d;
+            font-size: 1rem;
+        }
+        .office-hint {
+            margin-top: 1rem;
+            font-size: 0.9rem;
+            color: #7f8c8d;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<header class="header">
+    <div>
+        <span>📁</span>
+        <span th:text="${repoName}">repository.git</span>
+    </div>
+    <div>
+        <a th:if="${backUrl != null}" th:href="${backUrl}">← 返回仓库</a>
+    </div>
+</header>
+
+<div class="container">
+    <div class="card">
+        <h2>📄 <span th:text="${fileName}">文件名</span></h2>
+        <div class="info-grid">
+            <div class="info-label">分支</div>
+            <div class="info-value" th:text="${branch != null ? branch : '默认分支'}">main</div>
+            <div class="info-label">路径</div>
+            <div class="info-value" th:text="${filePath}">README.md</div>
+            <div class="info-label">大小</div>
+            <div class="info-value" th:text="${fileSizeFormatted}">1.2 KB</div>
+            <div class="info-label">类型</div>
+            <div class="info-value" th:text="${previewType}">text</div>
+        </div>
+        <div class="actions">
+            <a th:href="${downloadUrl}" class="btn">⬇️ 下载文件</a>
+            <a th:href="${rawUrl}" class="btn secondary" target="_blank" rel="noopener">查看原始内容</a>
+        </div>
+        <div class="preview-meta" th:if="${tooLargeForInline}">提示: 文件超过 1 MB，已禁用直接渲染，请下载或查看原始内容。</div>
+        <div class="preview-meta" th:if="${binaryDetected}">提示: 文件包含二进制内容，无法作为文本渲染。</div>
+    </div>
+
+    <div class="card preview-card">
+        <div th:if="${previewAvailable}">
+            <div th:if="${inlinePreview}" th:switch="${previewType}">
+                <div th:case="'text'">
+                    <pre><code th:class="${highlightLanguage != null} ? 'code-block hljs ' + highlightLanguage : 'code-block hljs'" th:text="${textContent}"></code></pre>
+                </div>
+                <div th:case="'markdown'">
+                    <article class="markdown-body" th:utext="${markdownHtml}"></article>
+                </div>
+                <div th:case="'image'" style="text-align:center;">
+                    <img th:src="${imageData}" alt="image preview" class="image-preview"/>
+                </div>
+                <div th:case="'pdf'">
+                    <iframe th:src="${pdfData}" class="pdf-frame"></iframe>
+                </div>
+                <div th:case="*">
+                    <div class="preview-placeholder">暂不支持该类型的内嵌预览，请下载查看。</div>
+                </div>
+            </div>
+
+            <div th:if="${clientRenderOffice}">
+                <div id="office-status" class="office-progress">正在加载 Office 文档预览...</div>
+                <div th:if="${previewType == 'word'}" id="docx-container" class="docx-wrapper"></div>
+                <div th:if="${previewType == 'excel'}" id="excel-container" class="excel-container"></div>
+                <div th:if="${previewType == 'powerpoint'}" id="ppt-container" class="docx-wrapper"></div>
+                <div class="office-hint">若预览失败，可尝试直接下载文件。</div>
+            </div>
+        </div>
+        <div th:if="${!previewAvailable}" class="preview-placeholder">
+            <p>暂不支持此文件类型的在线预览。</p>
+            <p>你仍然可以通过上方的按钮下载或查看原始内容。</p>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/lib/common.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/docx-preview@0.3.1/dist/docx-preview.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/pptxjs@2.12.0/dist/pptxjs.min.js"></script>
+<script th:inline="javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('pre code').forEach(function (block) {
+            if (window.hljs) {
+                window.hljs.highlightElement(block);
+            }
+        });
+    });
+
+    const clientRenderOffice = /*[[${clientRenderOffice}]]*/ false;
+    const rawUrl = /*[[${rawUrl}]]*/ '';
+    const previewType = /*[[${previewType}]]*/ 'binary';
+
+    if (clientRenderOffice && rawUrl) {
+        fetch(rawUrl)
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('无法加载文件');
+                }
+                return response.arrayBuffer();
+            })
+            .then(function (buffer) {
+                const statusEl = document.getElementById('office-status');
+                if (previewType === 'word' && window.docx) {
+                    const container = document.getElementById('docx-container');
+                    window.docx.renderAsync(buffer, container).then(function () {
+                        if (statusEl) {
+                            statusEl.remove();
+                        }
+                    }).catch(function (error) {
+                        if (statusEl) {
+                            statusEl.textContent = '预览失败: ' + error.message;
+                        }
+                    });
+                } else if (previewType === 'excel' && window.XLSX) {
+                    const container = document.getElementById('excel-container');
+                    if (!container) {
+                        return;
+                    }
+                    const workbook = window.XLSX.read(buffer, { type: 'array' });
+                    container.innerHTML = '';
+                    workbook.SheetNames.forEach(function (name, index) {
+                        const sheet = workbook.Sheets[name];
+                        const html = window.XLSX.utils.sheet_to_html(sheet, {
+                            header: '<h4>工作表 ' + (index + 1) + ': ' + name + '</h4>',
+                            editable: false
+                        });
+                        const section = document.createElement('section');
+                        section.innerHTML = html;
+                        container.appendChild(section);
+                    });
+                    if (statusEl) {
+                        statusEl.remove();
+                    }
+                } else if (previewType === 'powerpoint' && window.PPTX) {
+                    const container = document.getElementById('ppt-container');
+                    if (container) {
+                        const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.presentationml.presentation' });
+                        const url = URL.createObjectURL(blob);
+                        window.PPTX.load(url, '#ppt-container').then(function () {
+                            if (statusEl) {
+                                statusEl.remove();
+                            }
+                            URL.revokeObjectURL(url);
+                        }).catch(function (error) {
+                            if (statusEl) {
+                                statusEl.textContent = '预览失败: ' + error.message;
+                            }
+                            URL.revokeObjectURL(url);
+                        });
+                    }
+                } else if (statusEl) {
+                    statusEl.textContent = '当前环境缺少所需的预览库，请下载查看。';
+                }
+            })
+            .catch(function (error) {
+                const statusEl = document.getElementById('office-status');
+                if (statusEl) {
+                    statusEl.textContent = '预览失败: ' + error.message;
+                }
+            });
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add flexmark dependency and Git repository helpers to read blob metadata and content for previews
- implement file preview, raw, and download endpoints with preview-type detection and download headers in the web controller
- refresh repository detail links and add a dedicated preview template that renders text, markdown, images, pdf, and office files with highlight.js, docx-preview, SheetJS, and pptxjs integrations
- refactor the preview controller and repository service to normalize paths, resolve branches robustly, and improve mime-type detection for inline previews and downloads

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central to resolve Spring Boot dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6cb8304c833384494312c3a5b6e1